### PR TITLE
Feature/bedrock flow integration

### DIFF
--- a/story-teller/amplify/backend.ts
+++ b/story-teller/amplify/backend.ts
@@ -5,12 +5,21 @@ import { generateImage, MODEL_ID } from "./functions/generateImage/resource";
 import { Effect, PolicyStatement } from "aws-cdk-lib/aws-iam";
 import { storage, knowledgeBaseBucket } from "./storage/resource";
 import { getNews } from "./functions/getNews/resource";
+import {
+  invokeFlow,
+  REGION,
+  FLOW_IDENTIFIER as flowIdentifier,
+  FLOW_ALIAS_IDENTIFIER as flowAliasIdentifier,
+} from "./functions/invokeFlow/resource";
 
 const KB_REGION = "us-west-2";
 
 // Replace with your own Knowledge Base ID
 // https://docs.aws.amazon.com/bedrock/latest/userguide/knowledge-base-create.html
 const KB_ID = "F123456789";
+const FLOW_REGION = REGION;
+const FLOW_IDENTIFIER = flowIdentifier;
+const FLOW_ALIAS_IDENTIFIER = flowAliasIdentifier;
 
 const backend = defineBackend({
   auth,
@@ -19,6 +28,7 @@ const backend = defineBackend({
   storage,
   getNews,
   knowledgeBaseBucket,
+  invokeFlow,
 });
 
 backend.generateImage.resources.lambda.addToRolePolicy(
@@ -45,5 +55,33 @@ KnowledgeBaseDataSource.grantPrincipal.addToPrincipalPolicy(
   new PolicyStatement({
     resources: [`arn:aws:bedrock:${KB_REGION}:*:knowledge-base/${KB_ID}`],
     actions: ["bedrock:Retrieve"],
+  })
+);
+
+const bedrockFlowResources = [
+  `arn:aws:bedrock:${FLOW_REGION}:*:flow/${FLOW_IDENTIFIER}/alias/${FLOW_ALIAS_IDENTIFIER}`,
+  `arn:aws:bedrock:${FLOW_REGION}:*:flow/${FLOW_IDENTIFIER}`,
+];
+
+const bedrockFlowActions = [
+  "bedrock:InvokeFlow",
+  "bedrock-agent-runtime:InvokeFlow",
+  "bedrock-agent-runtime:InvokeAgentFlow",
+  "bedrock-agent-runtime:InvokeAgentFlowAlias",
+];
+
+backend.invokeFlow.resources.lambda.addToRolePolicy(
+  new PolicyStatement({
+    effect: Effect.ALLOW,
+    actions: bedrockFlowActions,
+    resources: bedrockFlowResources,
+  })
+);
+
+backend.auth.resources.authenticatedUserIamRole.addToPrincipalPolicy(
+  new PolicyStatement({
+    effect: Effect.ALLOW,
+    actions: bedrockFlowActions,
+    resources: bedrockFlowResources,
   })
 );

--- a/story-teller/amplify/data/resource.ts
+++ b/story-teller/amplify/data/resource.ts
@@ -1,6 +1,7 @@
 import { type ClientSchema, a, defineData } from "@aws-amplify/backend";
 import { generateImage } from "../functions/generateImage/resource";
 import { getNews } from "../functions/getNews/resource";
+import { invokeFlow } from "../functions/invokeFlow/resource";
 
 const schema = a.schema({
   Story: a
@@ -40,6 +41,14 @@ const schema = a.schema({
             "Used to search a knowledge base of style " +
             "dictionary documentation. Use it to help create story prompts",
           query: a.ref("knowledgeBase"),
+        }),
+        a.ai.dataTool({
+          name: "invokeFlow",
+          description:
+            "Connects to an Amazon Bedrock Flow to generate" +
+            "dynamic content based on user queries. " +
+            "The tool streams responses from Bedrock for optimal performance.",
+          query: a.ref("invokeFlow"),
         }),
       ],
     })
@@ -117,6 +126,19 @@ const schema = a.schema({
     )
     .returns(a.string())
     .authorization((allow) => [allow.authenticated()]),
+  invokeFlow: a
+    .query()
+    .arguments({
+      document: a.string(),
+    })
+    .returns(
+      a.customType({
+        title: a.string(),
+        description: a.string(),
+      })
+    )
+    .authorization((allow) => allow.authenticated())
+    .handler(a.handler.function(invokeFlow)),
 });
 export type Schema = ClientSchema<typeof schema>;
 

--- a/story-teller/amplify/functions/invokeFlow/handler.ts
+++ b/story-teller/amplify/functions/invokeFlow/handler.ts
@@ -1,0 +1,73 @@
+import type { Schema } from "../../data/resource";
+import {
+  BedrockAgentRuntimeClient,
+  InvokeFlowCommand,
+} from "@aws-sdk/client-bedrock-agent-runtime";
+import { env } from "$amplify/env/invokeFlow";
+
+// For more details see https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-agent-runtime_example_bedrock-agent-runtime_InvokeFlow_section.html
+
+const REGION = env.REGION;
+const FLOW_IDENTIFIER = env.FLOW_IDENTIFIER;
+const FLOW_ALIAS_IDENTIFIER = env.FLOW_ALIAS_IDENTIFIER;
+
+export const handler: Schema["invokeFlow"]["functionHandler"] = async (
+  event
+) => {
+  try {
+    const client = new BedrockAgentRuntimeClient({
+      region: REGION,
+      maxAttempts: 3,
+    });
+
+    console.log("Attempting to invoke flow with:", {
+      flowId: FLOW_IDENTIFIER,
+      aliasId: FLOW_ALIAS_IDENTIFIER,
+      input: event.arguments.document,
+    });
+
+    const command = new InvokeFlowCommand({
+      flowAliasIdentifier: FLOW_ALIAS_IDENTIFIER,
+      flowIdentifier: FLOW_IDENTIFIER,
+      inputs: [
+        {
+          content: {
+            document: event.arguments.document || "",
+          },
+          nodeName: "FlowInputNode",
+          nodeOutputName: "document",
+        },
+      ],
+      enableTrace: true,
+    });
+
+    let responseText = "";
+
+    const response = await client.send(command);
+
+    console.log(" FINAL Response", response);
+
+    if (response.responseStream) {
+      console.log(" FINAL responseStream", response.responseStream);
+      for await (const chunkEvent of response.responseStream!) {
+        const { flowOutputEvent } = chunkEvent;
+        if (flowOutputEvent?.content?.document) {
+          responseText += flowOutputEvent.content.document;
+        }
+      }
+    }
+    // Ensure we have a valid response
+    if (!responseText) {
+      responseText = "No response received from the flow.";
+    }
+
+    console.log(" FINAL output", responseText);
+    return {
+      title: responseText.split(" ").slice(0, 10).join(" ") as string,
+      description: responseText.split(" ").slice(10).join(" ") as string,
+    };
+  } catch (error) {
+    console.error("Error:", error);
+    throw error;
+  }
+};

--- a/story-teller/amplify/functions/invokeFlow/resource.ts
+++ b/story-teller/amplify/functions/invokeFlow/resource.ts
@@ -1,0 +1,16 @@
+import { defineFunction } from "@aws-amplify/backend";
+
+export const REGION = "us-east-1";
+export const FLOW_IDENTIFIER = "A123456789";
+export const FLOW_ALIAS_IDENTIFIER = "A12345678";
+
+export const invokeFlow = defineFunction({
+  name: "invokeFlow",
+  entry: "./handler.ts",
+  timeoutSeconds: 500,
+  environment: {
+    REGION,
+    FLOW_IDENTIFIER,
+    FLOW_ALIAS_IDENTIFIER,
+  },
+});


### PR DESCRIPTION
Issue #, if available:

Description of changes:

This PR adds an example integration of Amazon Bedrock Flow with AWS Amplify Gen 2, demonstrating how to build a chatbot using Next.js.

What does this example demonstrate?
Integration of Bedrock Flow with Amplify Gen 2 backend
Lambda function configuration for Flow invocation
IAM permission setup for secure Flow access
Schema integration with AppSync
Implementation Details
Added new Lambda function (invokeFlow):

Handler for Bedrock Flow interaction
Resource configuration for Flow integration
Updated backend configuration:

Added necessary IAM permissions in backend.ts
Integrated Flow with existing data schema
Modified data layer:

Updated resource.ts to support Flow integration
Added schema definitions for chat functionality
Testing Completed
 Tested locally with Amplify sandbox environment
 Verified Lambda function successfully invokes Bedrock Flow
 Confirmed IAM permissions are working correctly
 Validated integration with AppSync schema
Additional Context
This implementation is based on a working example detailed in my blog article ["How to Build a Chatbot with Amazon Bedrock Flow, AWS Amplify Gen 2, and Next.js".](https://awstip.com/converse-with-bedrock-flow-from-aws-amplify-gen-2-ai-kit-and-appsync-2611d7ebacd1) The article provides additional context and step-by-step implementation details.

Related Resources
Blog post with detailed implementation guide
Working example demonstrating the integration
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.